### PR TITLE
feat(avatarDropdown): options are conditional

### DIFF
--- a/src/views/components/header/avatarDropdown.ejs
+++ b/src/views/components/header/avatarDropdown.ejs
@@ -5,12 +5,15 @@
     </div>
   </button>
   <ul tabindex="-1" class="menu dropdown-content bg-base-200 rounded-box z-1 mt-3 w-52 p-2 shadow">
+    <% if (!locals.currentUser.is_member) { %>
     <li>
       <button onclick="becomeMemberModal.showModal()">Become a member</button>
     </li>
+    <% } else if (!locals.currentUser.is_admin) { %>
     <li>
       <button onclick="becomeAdminModal.showModal()">Join as admin</button>
     </li>
+    <% } %>
     <li>
       <a href="/logout">Logout</a>
     </li>


### PR DESCRIPTION
if user is admin, they only see 'log out'. if user is a member and not admin, they see the 'become an admin' button. if user is neither member nor admin, they just see the 'become a member' button

admin:
<img width="574" height="54" alt="image" src="https://github.com/user-attachments/assets/2206e96d-187a-4ec1-a610-943652b21ada" />
<img width="252" height="126" alt="image" src="https://github.com/user-attachments/assets/0f08191f-d52b-49fc-ae55-76abbd95bf2e" />

member but not admin:
<img width="565" height="50" alt="image" src="https://github.com/user-attachments/assets/2459126c-60ea-4014-9b8b-6618187892c6" />
<img width="265" height="161" alt="image" src="https://github.com/user-attachments/assets/93772077-71fd-460d-a0cf-c3ab0710ab86" />

merely authenticated but not a member:
<img width="282" height="163" alt="image" src="https://github.com/user-attachments/assets/f4a94c30-2b0b-483b-b2ad-65b723e45663" />